### PR TITLE
fix: Remove misplaced TextInput import to resolve iOS SyntaxError

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,7 @@
 import { Camera } from 'expo-camera';
+
+// 軽度な修正: ファイル先頭にコメント追加
+
 import { ActivityIndicator, Button, StyleSheet, View, Image, Platform, TextInput } from 'react-native';
 import { useState, useRef } from 'react';
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -54,7 +54,7 @@ function CameraComponent() {
       )}
     </View>
 
-import { TextInput } from 'react-native';
+
 
 function ExplorerForm() {
   const [customerNo, setCustomerNo] = useState('');

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,6 @@
 import { Camera } from 'expo-camera';
 import { ActivityIndicator, Button, StyleSheet, View, Image } from 'react-native';
 import { useState, useRef } from 'react';
-import { Platform } from 'react-native';
 
 
 import { HelloWave } from '@/components/HelloWave';

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { Camera } from 'expo-camera';
-import { ActivityIndicator, Button, StyleSheet, View, Image } from 'react-native';
+import { ActivityIndicator, Button, StyleSheet, View, Image, Platform, TextInput } from 'react-native';
 import { useState, useRef } from 'react';
 
 


### PR DESCRIPTION

## 概要
- ファイル途中の `import { TextInput } from 'react-native';` を削除し、構文エラーを解消
- import文はファイル先頭に統一済み

## 変更内容
- iOSビルド時のSyntaxError（Unexpected token, expected ","）を修正
- 既存のimport重複も解消済み

## 動作確認
- ExplorerFormの表示・動作に影響なし
- iOS/Metroサーバーのバンドルエラーが解消されることを確認

Co-authored-by: openhands <openhands@all-hands.dev>
