### PR TITLE
fix: wrap CameraComponent and ExplorerForm in fragment to resolve JSX error

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -96,7 +96,10 @@ const styles = StyleSheet.create({
 
 
       </ThemedView>
-      <CameraComponent />      <ExplorerForm />
+      <>
+        <CameraComponent />
+        <ExplorerForm />
+      </>
       
 
 >>    </ParallaxScrollView>


### PR DESCRIPTION

- CameraComponentとExplorerFormをフラグメントでラップし、JSX隣接要素エラーを解消
