### PR TITLE
fix: wrap CameraComponent and ExplorerForm in View to resolve JSX syntax error

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -96,10 +96,10 @@ const styles = StyleSheet.create({
 
 
       </ThemedView>
-      <>
+      <View>
         <CameraComponent />
         <ExplorerForm />
-      </>
+      </View>
       
 
 >>    </ParallaxScrollView>


### PR DESCRIPTION

- CameraComponentとExplorerFormをViewでラップし、JSX構文エラーを解消
