### PR TITLE
fix: remove explore route and add null check for ParallaxScrollView children

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -27,7 +27,6 @@ export default function TabLayout() {
         }),
       }}>
       <Tabs.Screen
-        name="explore"
         options={{
           title: 'Home',
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,

--- a/components/ParallaxScrollView.tsx
+++ b/components/ParallaxScrollView.tsx
@@ -59,7 +59,7 @@ export default function ParallaxScrollView({
           ]}>
           {headerImage}
         </Animated.View>
-        <ThemedView style={styles.content}>{children}</ThemedView>
+        <ThemedView style={styles.content}>{children ?? null}</ThemedView>
       </Animated.ScrollView>
     </ThemedView>
   );


### PR DESCRIPTION


- exploreルートの参照を削除
- ParallaxScrollViewのchildren描画部分にnullチェックを追加し、TypeErrorを解消

