### PR TITLE
Remove invalid 'explore' tab from Tabs layout to fix routing error

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -27,13 +27,6 @@ export default function TabLayout() {
         }),
       }}>
       <Tabs.Screen
-        name="explore"
-        options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
-        }}
-      />
-      <Tabs.Screen
         name="index"
         options={{
           title: 'Explore',


### PR DESCRIPTION

This PR removes the invalid 'explore' tab from the Tabs layout in `app/(tabs)/_layout.tsx`, resolving the routing error and warning about undefined routes.

- Only the Tabs layout file was changed.
- Fixes: No route named "undefined" exists in nested children: ["index"]

Co-authored-by: openhands <openhands@all-hands.dev>
