### PR TITLE
Fix: prevent undefined headerBackgroundColor access in ParallaxScrollView

### DIFF
--- a/components/ParallaxScrollView.tsx
+++ b/components/ParallaxScrollView.tsx
@@ -54,7 +54,7 @@ export default function ParallaxScrollView({
         <Animated.View
           style={[
             styles.header,
-            { backgroundColor: headerBackgroundColor[colorScheme] },
+            { backgroundColor: headerBackgroundColor[colorScheme] ?? headerBackgroundColor['light'] },
             headerAnimatedStyle,
           ]}>
           {headerImage}


### PR DESCRIPTION

This PR fixes a potential TypeError in ParallaxScrollView by ensuring headerBackgroundColor access is always safe, even if colorScheme is undefined or unexpected.

Co-authored-by: openhands &lt;openhands@all-hands.dev&gt;
