### PR TITLE
Remove explore tab, guide texts, and resolve merge conflict remnants

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -26,13 +26,7 @@ export default function TabLayout() {
           default: {},
         }),
       }}>
-      <Tabs.Screen
-        name="explore"
-        options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
-        }}
-      />
+
       <Tabs.Screen
         name="index"
         options={{

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -27,13 +27,6 @@ export default function TabLayout() {
         }),
       }}>
 
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
-        }}
-      />
     </Tabs>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -23,44 +23,11 @@ export default function HomeScreen() {
         <HelloWave />
       </ThemedView>
       <CameraComponent />
-<<<<<<< HEAD
       <ExplorerForm />
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-=======
+
 
       
 
->>>>>>> fb58f44 (WIP: stash before rebase)
     </ParallaxScrollView>
   );
 }


### PR DESCRIPTION

This PR removes the Explore tab and all guide texts from the UI, and resolves merge conflict remnants in app/(tabs)/index.tsx.

- Deleted Explore tab from TabLayout
- Removed all guide/step texts
- Cleaned up merge conflict markers

Co-authored-by: openhands &lt;openhands@all-hands.dev&gt;
