### PR TITLE
chore: add EXPO_PUBLIC_OPENAI_API_KEY to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
 
     "extra": {
       "OPENAI_API_KEY": "<secret_hidden>"
+      "EXPO_PUBLIC_OPENAI_API_KEY": "<secret_hidden>",
     },
 
     "name": "sumaho",


### PR DESCRIPTION

This PR adds `EXPO_PUBLIC_OPENAI_API_KEY` to the `app.json` extra section for Expo web compatibility.

Co-authored-by: openhands &lt;openhands@all-hands.dev&gt;
