### PR TITLE
fix: Camera import to resolve element type error

### DIFF
--- a/components/CameraComponent.tsx
+++ b/components/CameraComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, ScrollView, Button } from 'react-native';
-import { Camera } from 'expo-camera';
+import Camera from 'expo-camera';
 
 export default function CameraComponent() {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);


### PR DESCRIPTION

This PR fixes the import statement for Camera in CameraComponent.tsx to resolve the "Element type is invalid" error in React Native.  
- Changed `import { Camera } from 'expo-camera'` to `import Camera from 'expo-camera'`
- Verified that the app starts and the error is resolved

Co-authored-by: openhands <openhands@all-hands.dev>
