### PR TITLE
chore: specify node engine >=20.19.4 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "eslint-config-expo": "~10.0.0",
     "typescript": "~5.9.2"
   },
+
+  "engines": {
+    "node": ">=20.19.4"
+  },
+
   "private": true,
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION

## 概要
- package.jsonのenginesフィールドにNode.jsバージョン指定（>=20.19.4）を追加

## 目的
- Metro/Expo/React Native依存のNode.jsバージョン警告解消

Co-authored-by: openhands <openhands@all-hands.dev>
