### PR TITLE
chore: disable Hermes by setting jsEngine to jsc in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,9 @@
       "supportsTablet": true
     },
     "android": {
+
+      "jsEngine": "jsc",
+
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION


## 概要
- Hermesを無効化するため、app.jsonのandroidセクションに `"jsEngine": "jsc"` を追加

## 目的
- InternalBytecode.js関連のMetro/Expoエラー回避

Co-authored-by: openhands <openhands@all-hands.dev>

