### PR TITLE
fix: correct expo-camera import to named import

### DIFF
--- a/components/CameraComponent.tsx
+++ b/components/CameraComponent.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, Platform } from 'react-native';
-import Camera from 'expo-camera';
+import { Camera } from 'expo-camera';
 
 export default function CameraComponent() {
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);


### PR DESCRIPTION

## 概要
expo-cameraのimport方法をdefault importからnamed import（`{ Camera }`）に修正しました。

## 変更内容
- `components/CameraComponent.tsx` のimport文を修正

## 背景・理由
- default importのままだと "Element type is invalid" エラーが発生するため
- Expo公式ドキュメントに従いnamed importへ修正

## 動作確認
- アプリ起動時のカメラエラーが解消されることを確認

Co-authored-by: openhands <openhands@all-hands.dev>
